### PR TITLE
Quickfix, for `!config` alone making the bot crash

### DIFF
--- a/plugins/core/config/plugin.go
+++ b/plugins/core/config/plugin.go
@@ -103,6 +103,10 @@ func (p *Plugin) IsStarted() bool {
 }
 
 func (p *Plugin) processArgs(ib *irc.Connection, to string) {
+	if len(p.args) == 0 {
+		p.Start()
+		return
+	}
 	cnf := configuration.Config
 	switch p.args[0] {
 	case "save":


### PR DESCRIPTION
Now the bot doesnt crash anymore and its state is clean even if no command was given.
